### PR TITLE
Update hotcues-to-memory-cues.py

### DIFF
--- a/hotcues-to-memory-cues.py
+++ b/hotcues-to-memory-cues.py
@@ -18,9 +18,14 @@ for track in root.findall('./COLLECTION/TRACK'):
             print('processing: ' + track.get('Name'))
             child = ET.Element('POSITION_MARK')
             child.set('Name', '')
-            child.set('Type', '0')
+            child.set('Type', position.get('Type')) # does not change type value
             child.set('Num', '-1')
             child.set('Start', start)
+            #gets end value
+            temp = position.get("End")
+            if temp:
+            child.set('End', temp)
+            
             track.append(child)
 
 tree.write('output.xml', encoding='UTF-8', xml_declaration=True)


### PR DESCRIPTION
Fixes issue not transfering looped hot cues.
There is still an issue when importing them (having to load each individual song from the XML database at least once) but I suspect thats a Rekordbox bug.